### PR TITLE
Add startup error handling for Bot and update aiohttp dependency

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -4,7 +4,9 @@ import logging
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
+from aiogram.exceptions import TelegramNetworkError
 from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.utils.token import TokenValidationError
 
 from bot.checko_api import checko_api
 from bot.config import settings
@@ -22,33 +24,41 @@ logger = logging.getLogger(__name__)
 async def main() -> None:
     db = Database()
     await db.connect()
+    bot: Bot | None = None
 
-    bot = Bot(
-        token=settings.BOT_TOKEN,
-        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
-    )
-    dp = Dispatcher(storage=MemoryStorage())
-
-    # Middlewares
-    dp.message.middleware(ThrottlingMiddleware())
-    dp.message.middleware(DatabaseMiddleware(db))
-    dp.callback_query.middleware(DatabaseMiddleware(db))
-
-    # Inject checko_api into handler data
-    dp["checko_api"] = checko_api
-
-    # Routers
-    dp.include_router(start.router)
-    dp.include_router(search.router)
-    dp.include_router(callbacks.router)
-
-    logger.info("Starting bot…")
     try:
+        bot = Bot(
+            token=settings.BOT_TOKEN,
+            default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+        )
+        dp = Dispatcher(storage=MemoryStorage())
+
+        # Middlewares
+        dp.message.middleware(ThrottlingMiddleware())
+        dp.message.middleware(DatabaseMiddleware(db))
+        dp.callback_query.middleware(DatabaseMiddleware(db))
+
+        # Inject checko_api into handler data
+        dp["checko_api"] = checko_api
+
+        # Routers
+        dp.include_router(start.router)
+        dp.include_router(search.router)
+        dp.include_router(callbacks.router)
+
+        logger.info("Starting bot…")
         await dp.start_polling(bot)
+    except TokenValidationError:
+        logger.error("BOT_TOKEN is invalid. Update BOT_TOKEN in environment variables.")
+        raise SystemExit(1)
+    except TelegramNetworkError as exc:
+        logger.error("Cannot reach Telegram API: %s", exc)
+        raise SystemExit(1)
     finally:
         await db.close()
         await checko_api.close()
-        await bot.session.close()
+        if bot is not None:
+            await bot.session.close()
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiogram==3.7.0
-aiohttp==3.13.3
+aiohttp==3.9.5
 pydantic-settings==2.2.1
 python-dotenv==1.0.1
 aiosqlite==0.20.0


### PR DESCRIPTION
### Motivation
- Improve robustness of bot startup by handling token validation and network errors and ensuring resources are cleaned up.
- Align `aiohttp` dependency to a compatible version.

### Description
- Initialize `bot` as `None` and wrap bot creation and `dp.start_polling` in a `try/except/finally` block to catch `TokenValidationError` and `TelegramNetworkError`.
- Log an error and exit with `SystemExit(1)` when `BOT_TOKEN` is invalid and when the Telegram API is unreachable, and only close `bot.session` if `bot` was created.
- Add imports for `TokenValidationError` and `TelegramNetworkError`, and reorganize middleware and router setup inside the guarded block.
- Bump `aiohttp` from `3.13.3` to `3.9.5` in `requirements.txt`.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad85e053d0832a8169ac8eeb1a0013)