### PR TITLE
Add .env.example, ignore .env, and update README with configuration instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Telegram bot token from @BotFather
+BOT_TOKEN=your_bot_token_here
+
+# Checko API key from https://checko.ru/
+CHECKO_API_KEY=your_checko_api_key_here
+
+# Optional: custom Checko API base URL
+CHECKO_API_URL=https://api.checko.ru/v2
+
+# Path to SQLite database file
+DATABASE_PATH=bot.db

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ env/
 .idea/
 .vscode/
 *.swp
+
+# Environment
+.env

--- a/README.md
+++ b/README.md
@@ -45,15 +45,23 @@ pip install -r requirements.txt
 
 ## Конфигурация
 
-Скопируйте `.env` и заполните значения:
+Скопируйте шаблон и заполните значения:
 
+```bash
+cp .env.example .env
 ```
+
+```env
 BOT_TOKEN=your_bot_token_here
 CHECKO_API_KEY=your_checko_api_key_here
+CHECKO_API_URL=https://api.checko.ru/v2
+DATABASE_PATH=bot.db
 ```
 
 - `BOT_TOKEN` — токен бота от [@BotFather](https://t.me/BotFather)
 - `CHECKO_API_KEY` — ключ API от [checko.ru](https://checko.ru/)
+- `CHECKO_API_URL` — базовый URL Checko API (опционально)
+- `DATABASE_PATH` — путь к SQLite-файлу (по умолчанию `bot.db`)
 
 ## Запуск
 


### PR DESCRIPTION
### Motivation
- Provide a committed example environment file and document configuration so contributors can set up the bot without exposing secrets. 
- Ensure local `.env` files are not accidentally committed by adding it to `.gitignore` and document optional Checko and DB settings.

### Description
- Add `.env.example` containing `BOT_TOKEN`, `CHECKO_API_KEY`, optional `CHECKO_API_URL`, and `DATABASE_PATH` template entries.
- Update `.gitignore` to exclude `.env` and keep local secret files out of the repository.
- Update `README.md` to instruct copying the template with `cp .env.example .env`, display the example environment variables, and document the new optional settings.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8f267580832ab9023c704cc3980d)