### PR TITLE
Refactor config loading and CheckoAPI client; validate env and wire dependencies in main

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # Telegram bot token from @BotFather
-BOT_TOKEN=8512654756:AAEJ0bp0w9hMF8LuCwS190GFpWN2ZSrpk3w
+BOT_TOKEN=your_bot_token_here
 
 # Checko API key from https://checko.ru/
-CHECKO_API_KEY=eShKcLHfkIzN3puL
+CHECKO_API_KEY=your_checko_api_key_here
 
 # Optional: custom Checko API base URL
 CHECKO_API_URL=https://api.checko.ru/v2

--- a/bot/checko_api.py
+++ b/bot/checko_api.py
@@ -1,8 +1,6 @@
 import aiohttp
 from typing import Any
 
-from bot.config import settings
-
 
 class CheckoAPIError(Exception):
     """Raised when Checko API returns an error."""
@@ -15,9 +13,9 @@ class CheckoAPIError(Exception):
 class CheckoAPI:
     """Async client for the Checko API."""
 
-    def __init__(self) -> None:
-        self._base_url = settings.CHECKO_API_URL.rstrip("/")
-        self._key = settings.CHECKO_API_KEY
+    def __init__(self, base_url: str, key: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._key = key
         self._session: aiohttp.ClientSession | None = None
 
     async def _get_session(self) -> aiohttp.ClientSession:
@@ -118,6 +116,3 @@ class CheckoAPI:
     async def search(self, query: str) -> dict:
         """Search companies and entrepreneurs by name or INN."""
         return await self._get("search", query=query)
-
-
-checko_api = CheckoAPI()

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,21 +1,60 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+from dotenv import load_dotenv
 
 
-class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
-
-    # Telegram
+@dataclass(frozen=True)
+class Settings:
     BOT_TOKEN: str
-
-    # Checko API
     CHECKO_API_KEY: str
     CHECKO_API_URL: str = "https://api.checko.ru/v2"
-
-    # Database
     DATABASE_PATH: str = "bot.db"
-
-    # Rate limiting (requests per second per user)
     THROTTLE_RATE: float = 0.5
 
 
-settings = Settings()
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    load_dotenv()
+
+    bot_token = (os.getenv("BOT_TOKEN") or "").strip()
+    checko_api_key = (os.getenv("CHECKO_API_KEY") or "").strip()
+    checko_api_url = (os.getenv("CHECKO_API_URL") or "https://api.checko.ru/v2").strip()
+    database_path = (os.getenv("DATABASE_PATH") or "bot.db").strip()
+    throttle_rate_raw = (os.getenv("THROTTLE_RATE") or "0.5").strip()
+
+    if not bot_token or not checko_api_key:
+        raise RuntimeError(
+            "Environment is not configured. Set BOT_TOKEN and CHECKO_API_KEY in .env or environment variables."
+        )
+
+    try:
+        throttle_rate = float(throttle_rate_raw)
+    except ValueError as exc:
+        raise RuntimeError("THROTTLE_RATE must be a valid float value.") from exc
+
+    if throttle_rate <= 0:
+        raise RuntimeError("THROTTLE_RATE must be greater than 0.")
+
+    return Settings(
+        BOT_TOKEN=bot_token,
+        CHECKO_API_KEY=checko_api_key,
+        CHECKO_API_URL=checko_api_url,
+        DATABASE_PATH=database_path,
+        THROTTLE_RATE=throttle_rate,
+    )
+
+
+def load_settings() -> Settings:
+    settings = get_settings()
+
+    placeholders = {"your_bot_token_here", "your_checko_api_key_here"}
+    if settings.BOT_TOKEN in placeholders or settings.CHECKO_API_KEY in placeholders:
+        raise RuntimeError(
+            "Environment contains placeholder credentials. Update BOT_TOKEN and CHECKO_API_KEY before запуском бота."
+        )
+
+    return settings

--- a/bot/database/db.py
+++ b/bot/database/db.py
@@ -1,12 +1,13 @@
 import aiosqlite
 
-from bot.config import settings
+from bot.config import load_settings
 
 
 class Database:
     """Async SQLite database wrapper."""
 
     def __init__(self, path: str | None = None) -> None:
+        settings = load_settings()
         self._path = path or settings.DATABASE_PATH
         self._conn: aiosqlite.Connection | None = None
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -8,8 +8,8 @@ from aiogram.exceptions import TelegramNetworkError
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.utils.token import TokenValidationError
 
-from bot.checko_api import checko_api
-from bot.config import settings
+from bot.checko_api import CheckoAPI
+from bot.config import load_settings
 from bot.database.db import Database
 from bot.handlers import callbacks, search, start
 from bot.middlewares import DatabaseMiddleware, ThrottlingMiddleware
@@ -22,6 +22,17 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
+    try:
+        settings = load_settings()
+    except RuntimeError as exc:
+        logger.error(str(exc))
+        raise SystemExit(1) from exc
+
+    checko_api = CheckoAPI(
+        base_url=settings.CHECKO_API_URL,
+        key=settings.CHECKO_API_KEY,
+    )
+
     db = Database()
     await db.connect()
     bot: Bot | None = None

--- a/bot/middlewares.py
+++ b/bot/middlewares.py
@@ -4,7 +4,7 @@ from typing import Any, Awaitable, Callable
 from aiogram import BaseMiddleware
 from aiogram.types import Message, TelegramObject
 
-from bot.config import settings
+from bot.config import load_settings
 from bot.database.db import Database
 
 
@@ -12,6 +12,7 @@ class ThrottlingMiddleware(BaseMiddleware):
     """Rate-limit middleware: limits each user to THROTTLE_RATE messages/sec."""
 
     def __init__(self, rate: float | None = None) -> None:
+        settings = load_settings()
         self._rate = rate if rate is not None else settings.THROTTLE_RATE
         self._locks: dict[int, asyncio.Lock] = {}
         self._last_call: dict[int, float] = {}


### PR DESCRIPTION
### Motivation

- Remove implicit global configuration and secret values to make configuration explicit and safer.
- Decouple `CheckoAPI` from global settings so it can be instantiated with explicit credentials for better testability and lifecycle management.
- Validate environment at startup to fail fast when required variables are missing or placeholders are present.

### Description

- Rewrote config handling: replaced `pydantic_settings` usage with a frozen `@dataclass` `Settings` and factory functions `get_settings()` and `load_settings()` that use `dotenv` and `lru_cache` to load and validate env vars, parse `THROTTLE_RATE`, and reject placeholder credentials found in `.env`.
- Changed `.env` to use placeholder values for `BOT_TOKEN` and `CHECKO_API_KEY` to avoid committing real secrets.
- Modified `CheckoAPI` to accept `base_url` and `key` in its constructor and removed the module-level `checko_api` instance so the client is instantiated explicitly in `main`.
- Updated `main` to call `load_settings()`, construct `CheckoAPI`, and inject it into the dispatcher, and to exit early with an error if settings are invalid.
- Updated `Database` and `ThrottlingMiddleware` to obtain configuration via `load_settings()` instead of relying on a global `settings` object.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad95cb3604832a8bc4e3e625ceb75c)