### PR TITLE
Support TELEGRAM_TOKEN fallback and harden placeholder env validation

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -20,7 +20,10 @@ class Settings:
 def get_settings() -> Settings:
     load_dotenv()
 
-    bot_token = (os.getenv("BOT_TOKEN") or "").strip()
+    bot_token = (
+        (os.getenv("BOT_TOKEN") or "").strip()
+        or (os.getenv("TELEGRAM_TOKEN") or "").strip()
+    )
     checko_api_key = (os.getenv("CHECKO_API_KEY") or "").strip()
     checko_api_url = (os.getenv("CHECKO_API_URL") or "https://api.checko.ru/v2").strip()
     database_path = (os.getenv("DATABASE_PATH") or "bot.db").strip()
@@ -28,7 +31,7 @@ def get_settings() -> Settings:
 
     if not bot_token or not checko_api_key:
         raise RuntimeError(
-            "Environment is not configured. Set BOT_TOKEN and CHECKO_API_KEY in .env or environment variables."
+            "Environment is not configured. Set BOT_TOKEN (or TELEGRAM_TOKEN) and CHECKO_API_KEY in .env or environment variables."
         )
 
     try:
@@ -51,10 +54,20 @@ def get_settings() -> Settings:
 def load_settings() -> Settings:
     settings = get_settings()
 
-    placeholders = {"your_bot_token_here", "your_checko_api_key_here"}
-    if settings.BOT_TOKEN in placeholders or settings.CHECKO_API_KEY in placeholders:
+    placeholders = {
+        "your_bot_token_here",
+        "your_bot_token",
+        "your_checko_api_key_here",
+        "your_checko_api_key",
+        "your_checko_key_here",
+        "changeme",
+    }
+    if (
+        settings.BOT_TOKEN.lower() in placeholders
+        or settings.CHECKO_API_KEY.lower() in placeholders
+    ):
         raise RuntimeError(
-            "Environment contains placeholder credentials. Update BOT_TOKEN and CHECKO_API_KEY before запуском бота."
+            "Environment contains placeholder credentials. Update BOT_TOKEN (or TELEGRAM_TOKEN) and CHECKO_API_KEY before starting the bot."
         )
 
     return settings


### PR DESCRIPTION
### Motivation
- Устранить ситуацию, когда бот падает при отсутствии `BOT_TOKEN`, хотя в окружении задано `TELEGRAM_TOKEN`.
- Защитить запуск от случайных плейсхолдеров (`your_*`, `changeme` и т.п.), которые сейчас могут пропустить проверку и привести к неинформативным ошибкам.

### Description
- Добавлен fallback: при пустом `BOT_TOKEN` читаем `TELEGRAM_TOKEN` (логика в `get_settings`).【F:bot/config.py†L23-L27】
- Расширена и сделана регистронезависимой проверка плейсхолдеров для `BOT_TOKEN`/`CHECKO_API_KEY` (новые варианты: `your_bot_token`, `your_checko_key_here`, `changeme`).【F:bot/config.py†L54-L71】
- Обновлены сообщения об ошибках, чтобы явно упоминать `BOT_TOKEN (or TELEGRAM_TOKEN)` и давать понятный призыв к действию.【F:bot/config.py†L32-L35】【F:bot/config.py†L69-L71】

### Testing
- Запуск компиляции кода прошёл успешно: `python -m compileall bot`.【40a8f3†L1-L15】
- Прогон дымовой проверки подтвердил: fallback с `TELEGRAM_TOKEN` работает и плейсхолдеры блокируются на старте (скрипт-микротест).【f4e649†L1-L2】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9e057a30832abf60b391f6cd866e)