### PR TITLE
Improve placeholder credential validation and BOT_TOKEN fallback; add coverage tests

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -3,8 +3,21 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from functools import lru_cache
+from typing import Iterable, List
 
 from dotenv import load_dotenv
+
+TOKEN_PLACEHOLDERS = {
+    "your_bot_token_here",
+    "your_bot_token",
+    "changeme",
+}
+CHECKO_PLACEHOLDERS = {
+    "your_checko_api_key_here",
+    "your_checko_api_key",
+    "your_checko_key_here",
+    "changeme",
+}
 
 
 @dataclass(frozen=True)
@@ -16,14 +29,24 @@ class Settings:
     THROTTLE_RATE: float = 0.5
 
 
+def _is_placeholder(value: str, placeholders: Iterable[str]) -> bool:
+    return value.lower() in placeholders
+
+
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
     load_dotenv()
 
-    bot_token = (
-        (os.getenv("BOT_TOKEN") or "").strip()
-        or (os.getenv("TELEGRAM_TOKEN") or "").strip()
-    )
+    bot_token_raw = (os.getenv("BOT_TOKEN") or "").strip()
+    telegram_token_raw = (os.getenv("TELEGRAM_TOKEN") or "").strip()
+
+    bot_token = bot_token_raw
+    if (
+        (not bot_token or _is_placeholder(bot_token, TOKEN_PLACEHOLDERS))
+        and telegram_token_raw
+    ):
+        bot_token = telegram_token_raw
+
     checko_api_key = (os.getenv("CHECKO_API_KEY") or "").strip()
     checko_api_url = (os.getenv("CHECKO_API_URL") or "https://api.checko.ru/v2").strip()
     database_path = (os.getenv("DATABASE_PATH") or "bot.db").strip()
@@ -54,20 +77,17 @@ def get_settings() -> Settings:
 def load_settings() -> Settings:
     settings = get_settings()
 
-    placeholders = {
-        "your_bot_token_here",
-        "your_bot_token",
-        "your_checko_api_key_here",
-        "your_checko_api_key",
-        "your_checko_key_here",
-        "changeme",
-    }
-    if (
-        settings.BOT_TOKEN.lower() in placeholders
-        or settings.CHECKO_API_KEY.lower() in placeholders
-    ):
+    invalid_fields: List[str] = []
+    if _is_placeholder(settings.BOT_TOKEN, TOKEN_PLACEHOLDERS):
+        invalid_fields.append("BOT_TOKEN (or TELEGRAM_TOKEN)")
+    if _is_placeholder(settings.CHECKO_API_KEY, CHECKO_PLACEHOLDERS):
+        invalid_fields.append("CHECKO_API_KEY")
+
+    if invalid_fields:
         raise RuntimeError(
-            "Environment contains placeholder credentials. Update BOT_TOKEN (or TELEGRAM_TOKEN) and CHECKO_API_KEY before starting the bot."
+            "Environment contains placeholder credentials for: "
+            + ", ".join(invalid_fields)
+            + ". Replace placeholder values in .env before starting the bot."
         )
 
     return settings

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+import os
+import unittest
+from contextlib import contextmanager
+from typing import Dict
+
+from bot.config import get_settings, load_settings
+
+
+@contextmanager
+def temp_env(overrides: Dict[str, str]):
+    original = os.environ.copy()
+    try:
+        os.environ.clear()
+        os.environ.update(overrides)
+        get_settings.cache_clear()
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original)
+        get_settings.cache_clear()
+
+
+class ConfigSettingsTests(unittest.TestCase):
+    def test_fallback_to_telegram_token_when_bot_token_is_placeholder(self) -> None:
+        with temp_env(
+            {
+                "BOT_TOKEN": "your_bot_token_here",
+                "TELEGRAM_TOKEN": "12345:abc",
+                "CHECKO_API_KEY": "real_key",
+            }
+        ):
+            settings = load_settings()
+
+        self.assertEqual(settings.BOT_TOKEN, "12345:abc")
+
+    def test_reports_both_placeholder_credentials(self) -> None:
+        with temp_env(
+            {
+                "BOT_TOKEN": "your_bot_token_here",
+                "TELEGRAM_TOKEN": "your_bot_token",
+                "CHECKO_API_KEY": "your_checko_api_key_here",
+            }
+        ):
+            with self.assertRaises(RuntimeError) as exc:
+                load_settings()
+
+        self.assertIn("BOT_TOKEN (or TELEGRAM_TOKEN)", str(exc.exception))
+        self.assertIn("CHECKO_API_KEY", str(exc.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent running the bot with placeholder credentials and give clearer error messages identifying which environment variables are invalid.
- Accept `TELEGRAM_TOKEN` as a fallback when `BOT_TOKEN` is unset or set to a placeholder so real tokens are not ignored.

### Description
- Introduce `TOKEN_PLACEHOLDERS` and `CHECKO_PLACEHOLDERS` sets and a helper `_is_placeholder` to centralize placeholder detection.
- Change BOT token selection to prefer `BOT_TOKEN` but fall back to `TELEGRAM_TOKEN` when `BOT_TOKEN` is missing or a placeholder.
- Improve `load_settings` validation to report specific invalid fields in the raised `RuntimeError` instead of a generic message.
- Add `tests/test_config.py` with unit tests covering the fallback behavior and placeholder reporting, and add a `temp_env` helper to isolate environment variables during tests.

### Testing
- Ran the new unit tests with `python -m unittest tests/test_config.py`, which executed `test_fallback_to_telegram_token_when_bot_token_is_placeholder` and `test_reports_both_placeholder_credentials` and both tests passed.
- Ran test discovery with `python -m unittest discover` and no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9fbb9264832ab71a28b63baf19ba)