### PR TITLE
Add retries/timeouts to CheckoAPI and resilient polling with IPv4 aiohttp session

### DIFF
--- a/bot/checko_api.py
+++ b/bot/checko_api.py
@@ -1,5 +1,7 @@
-import aiohttp
+import asyncio
 from typing import Any
+
+import aiohttp
 
 
 class CheckoAPIError(Exception):
@@ -13,14 +15,24 @@ class CheckoAPIError(Exception):
 class CheckoAPI:
     """Async client for the Checko API."""
 
-    def __init__(self, base_url: str, key: str) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        key: str,
+        timeout_seconds: int = 20,
+        max_retries: int = 3,
+        retry_delay_seconds: float = 1.5,
+    ) -> None:
         self._base_url = base_url.rstrip("/")
         self._key = key
         self._session: aiohttp.ClientSession | None = None
+        self._timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        self._max_retries = max_retries
+        self._retry_delay_seconds = retry_delay_seconds
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
         return self._session
 
     async def close(self) -> None:
@@ -31,15 +43,44 @@ class CheckoAPI:
         session = await self._get_session()
         params["key"] = self._key
         url = f"{self._base_url}/{endpoint.lstrip('/')}"
-        async with session.get(url, params=params) as resp:
-            if resp.status != 200:
-                raise CheckoAPIError(
-                    f"API request failed: {resp.status}", status_code=resp.status
-                )
-            data = await resp.json()
-            if isinstance(data, dict) and data.get("error"):
-                raise CheckoAPIError(data["error"])
-            return data
+
+        last_error: Exception | None = None
+
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                async with session.get(url, params=params) as resp:
+                    if 500 <= resp.status < 600:
+                        raise CheckoAPIError(
+                            f"Checko server error: {resp.status}", status_code=resp.status
+                        )
+                    if resp.status != 200:
+                        raise CheckoAPIError(
+                            f"API request failed: {resp.status}", status_code=resp.status
+                        )
+
+                    data = await resp.json()
+                    if isinstance(data, dict) and data.get("error"):
+                        raise CheckoAPIError(data["error"])
+                    return data
+            except CheckoAPIError as exc:
+                if exc.status_code and 500 <= exc.status_code < 600:
+                    last_error = exc
+                else:
+                    raise
+            except (
+                aiohttp.ClientConnectionError,
+                aiohttp.ClientOSError,
+                aiohttp.ServerTimeoutError,
+                asyncio.TimeoutError,
+                aiohttp.ClientPayloadError,
+            ) as exc:
+                last_error = exc
+
+            if attempt >= self._max_retries:
+                break
+            await asyncio.sleep(self._retry_delay_seconds * attempt)
+
+        raise CheckoAPIError(f"Checko request failed after retries: {last_error}")
 
     # --- Company (ЮЛ) ---
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,8 +1,11 @@
 import asyncio
 import logging
+import socket
+import sys
 
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
+from aiogram.client.session.aiohttp import AiohttpSession
 from aiogram.enums import ParseMode
 from aiogram.exceptions import TelegramNetworkError
 from aiogram.fsm.storage.memory import MemoryStorage
@@ -17,8 +20,34 @@ from bot.middlewares import DatabaseMiddleware, ThrottlingMiddleware
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
 )
 logger = logging.getLogger(__name__)
+
+
+async def run_polling(dp: Dispatcher, bot: Bot) -> None:
+    backoff_seconds = 3
+
+    while True:
+        try:
+            logger.info("Starting bot...")
+            await dp.start_polling(bot)
+        except asyncio.CancelledError:
+            logger.info("Polling cancelled")
+            raise
+        except TelegramNetworkError as exc:
+            logger.error("Cannot reach Telegram API: %s", exc)
+            logger.info("Restarting polling in %s sec...", backoff_seconds)
+            await asyncio.sleep(backoff_seconds)
+            backoff_seconds = min(backoff_seconds * 2, 60)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.exception("Polling crashed: %s", exc)
+            logger.info("Restarting polling in %s sec...", backoff_seconds)
+            await asyncio.sleep(backoff_seconds)
+            backoff_seconds = min(backoff_seconds * 2, 60)
+        else:
+            logger.info("Polling stopped normally")
+            break
 
 
 async def main() -> None:
@@ -38,8 +67,11 @@ async def main() -> None:
     bot: Bot | None = None
 
     try:
+        session = AiohttpSession()
+        session._connector_init["family"] = socket.AF_INET
         bot = Bot(
             token=settings.BOT_TOKEN,
+            session=session,
             default=DefaultBotProperties(parse_mode=ParseMode.HTML),
         )
         dp = Dispatcher(storage=MemoryStorage())
@@ -57,13 +89,9 @@ async def main() -> None:
         dp.include_router(search.router)
         dp.include_router(callbacks.router)
 
-        logger.info("Starting bot…")
-        await dp.start_polling(bot)
+        await run_polling(dp, bot)
     except TokenValidationError:
         logger.error("BOT_TOKEN is invalid. Update BOT_TOKEN in environment variables.")
-        raise SystemExit(1)
-    except TelegramNetworkError as exc:
-        logger.error("Cannot reach Telegram API: %s", exc)
         raise SystemExit(1)
     finally:
         await db.close()


### PR DESCRIPTION
### Motivation
- Improve reliability of Checko API calls by adding timeouts and retry logic to handle transient network or server errors.  
- Make the Telegram bot more resilient to network issues by running polling in a restartable loop with exponential backoff and force IPv4 for the aiohttp connector to avoid possible IPv6 connectivity problems.  

### Description
- Extended `CheckoAPI` constructor with `timeout_seconds`, `max_retries`, and `retry_delay_seconds` parameters and configured an `aiohttp.ClientTimeout` for the client session.  
- Implemented retry loop in `CheckoAPI._get` that retries on connection/timeouts and 5xx server errors, with backoff between attempts, and surfaces a `CheckoAPIError` after exhausting retries.  
- Updated `main.py` to set logging output to `sys.stdout`, create an `AiohttpSession` forced to use IPv4 by setting `session._connector_init["family"] = socket.AF_INET`, and pass that session into `Bot`.  
- Added `run_polling` wrapper that restarts `dp.start_polling` on network errors or unexpected crashes with exponential backoff, and ensured proper shutdown of database, Checko API session, and bot session.  

### Testing
- Ran the existing unit test suite with `pytest -q` against the modified code and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada20c9424832a97f715cebcb7f5bb)