### PR TITLE
Add configurable polling retry limit for network failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ CHECKO_API_URL=https://api.checko.ru/v2
 
 # Path to SQLite database file
 DATABASE_PATH=bot.db
+
+# Optional: maximum Telegram API reconnect attempts before exit
+# POLLING_MAX_RETRIES=5

--- a/bot/config.py
+++ b/bot/config.py
@@ -27,6 +27,7 @@ class Settings:
     CHECKO_API_URL: str = "https://api.checko.ru/v2"
     DATABASE_PATH: str = "bot.db"
     THROTTLE_RATE: float = 0.5
+    POLLING_MAX_RETRIES: int | None = None
 
 
 def _is_placeholder(value: str, placeholders: Iterable[str]) -> bool:
@@ -51,6 +52,7 @@ def get_settings() -> Settings:
     checko_api_url = (os.getenv("CHECKO_API_URL") or "https://api.checko.ru/v2").strip()
     database_path = (os.getenv("DATABASE_PATH") or "bot.db").strip()
     throttle_rate_raw = (os.getenv("THROTTLE_RATE") or "0.5").strip()
+    polling_max_retries_raw = (os.getenv("POLLING_MAX_RETRIES") or "").strip()
 
     if not bot_token or not checko_api_key:
         raise RuntimeError(
@@ -65,12 +67,23 @@ def get_settings() -> Settings:
     if throttle_rate <= 0:
         raise RuntimeError("THROTTLE_RATE must be greater than 0.")
 
+    polling_max_retries: int | None = None
+    if polling_max_retries_raw:
+        try:
+            polling_max_retries = int(polling_max_retries_raw)
+        except ValueError as exc:
+            raise RuntimeError("POLLING_MAX_RETRIES must be a valid integer.") from exc
+
+        if polling_max_retries <= 0:
+            raise RuntimeError("POLLING_MAX_RETRIES must be greater than 0.")
+
     return Settings(
         BOT_TOKEN=bot_token,
         CHECKO_API_KEY=checko_api_key,
         CHECKO_API_URL=checko_api_url,
         DATABASE_PATH=database_path,
         THROTTLE_RATE=throttle_rate,
+        POLLING_MAX_RETRIES=polling_max_retries,
     )
 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -25,8 +25,9 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-async def run_polling(dp: Dispatcher, bot: Bot) -> None:
+async def run_polling(dp: Dispatcher, bot: Bot, max_retries: int | None = None) -> None:
     backoff_seconds = 3
+    network_failures = 0
 
     while True:
         try:
@@ -36,7 +37,12 @@ async def run_polling(dp: Dispatcher, bot: Bot) -> None:
             logger.info("Polling cancelled")
             raise
         except TelegramNetworkError as exc:
+            network_failures += 1
             logger.error("Cannot reach Telegram API: %s", exc)
+            if max_retries is not None and network_failures >= max_retries:
+                raise RuntimeError(
+                    f"Telegram API is unreachable after {network_failures} attempts."
+                ) from exc
             logger.info("Restarting polling in %s sec...", backoff_seconds)
             await asyncio.sleep(backoff_seconds)
             backoff_seconds = min(backoff_seconds * 2, 60)
@@ -89,10 +95,13 @@ async def main() -> None:
         dp.include_router(search.router)
         dp.include_router(callbacks.router)
 
-        await run_polling(dp, bot)
+        await run_polling(dp, bot, settings.POLLING_MAX_RETRIES)
     except TokenValidationError:
         logger.error("BOT_TOKEN is invalid. Update BOT_TOKEN in environment variables.")
         raise SystemExit(1)
+    except RuntimeError as exc:
+        logger.error(str(exc))
+        raise SystemExit(1) from exc
     finally:
         await db.close()
         await checko_api.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,31 @@ class ConfigSettingsTests(unittest.TestCase):
         self.assertIn("BOT_TOKEN (or TELEGRAM_TOKEN)", str(exc.exception))
         self.assertIn("CHECKO_API_KEY", str(exc.exception))
 
+    def test_reads_polling_max_retries_when_set(self) -> None:
+        with temp_env(
+            {
+                "BOT_TOKEN": "12345:abc",
+                "CHECKO_API_KEY": "real_key",
+                "POLLING_MAX_RETRIES": "2",
+            }
+        ):
+            settings = load_settings()
+
+        self.assertEqual(settings.POLLING_MAX_RETRIES, 2)
+
+    def test_rejects_non_positive_polling_max_retries(self) -> None:
+        with temp_env(
+            {
+                "BOT_TOKEN": "12345:abc",
+                "CHECKO_API_KEY": "real_key",
+                "POLLING_MAX_RETRIES": "0",
+            }
+        ):
+            with self.assertRaises(RuntimeError) as exc:
+                load_settings()
+
+        self.assertIn("POLLING_MAX_RETRIES must be greater than 0", str(exc.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent the bot from looping forever when Telegram is unreachable by allowing an operator to configure a maximum number of reconnect attempts.
- Make retry behavior explicit and configurable via environment so operators can choose fail-fast or long-running modes.

### Description
- Added a new optional `POLLING_MAX_RETRIES: int | None` setting parsed from `POLLING_MAX_RETRIES` with strict integer and positive validation in `bot/config.py` (settings and parsing logic). 【F:bot/config.py†L23-L31】【F:bot/config.py†L54-L87】
- Updated polling loop in `bot/main.py` to count `TelegramNetworkError` occurrences and raise a clear `RuntimeError` when the configured retry limit is reached, and propagated the setting into `run_polling`. 【F:bot/main.py†L28-L56】【F:bot/main.py†L98-L104】
- Documented the optional setting in `.env.example` and added unit tests covering valid and invalid `POLLING_MAX_RETRIES` values in `tests/test_config.py`. 【F:.env.example†L13-L14】【F:tests/test_config.py†L50-L74】

### Testing
- Ran config unit tests with `python -m unittest discover -s tests -v` and all config tests passed (4 tests). 【17c6e5†L1-L10】
- Verified runtime behavior by starting the bot with `POLLING_MAX_RETRIES=1`; the process exits with a clear fatal error after one failed attempt when the network is unreachable (behaviour exercised in restricted CI-like environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada77da840832aa98f2e672d7faf63)