### PR TITLE
docs: add note about POLLING_MAX_RETRIES for restricted networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ DATABASE_PATH=bot.db
 python -m bot.main
 ```
 
+Если бот запускается в среде с ограниченным исходящим доступом в интернет, можно задать `POLLING_MAX_RETRIES=1`, чтобы процесс завершался после первой неудачной попытки подключения к Telegram API.
+
 ## Технологии
 
 - [aiogram 3.x](https://docs.aiogram.dev/) — Telegram Bot framework


### PR DESCRIPTION
### Motivation
- Make local smoke runs deterministic in environments with blocked outbound access to Telegram by explaining how to stop polling after the first failure (documentation-only change).【F:README.md†L71-L71】

### Description
- Added a short note to the `README.md` `Run` section explaining `POLLING_MAX_RETRIES=1` can be used to make the process exit after a single failed attempt to reach the Telegram API.【F:README.md†L65-L73】

### Testing
- `pip install -r requirements.txt` completed successfully (dependencies present).【3b9664†L1-L6】
- Running `pytest -q` without `PYTHONPATH` failed on import path (ModuleNotFoundError), while `PYTHONPATH=. pytest -q` passed (`8 passed`).【ee3042†L1-L12】【4eebfe†L1-L2】
- Verified `POLLING_MAX_RETRIES=1 python -m bot.main` causes the process to stop after one failed attempt to contact Telegram in this restricted environment (expected behavior).【9d49b5†L1-L5】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addaf2de98832ab2b7c4bb536393c4)