### PR TITLE
docs: add 'Production operations' runbook to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,58 @@ python -m pip install -e .
 dadata-enrichment
 ```
 
+## Production operations
+
+### Команды
+
+- **Health check**
+
+```bash
+curl -i "$WORKER_URL/"
+```
+
+Ожидается HTTP `200`.
+
+- **Webhook check (Telegram getWebhookInfo)**
+
+```bash
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo"
+```
+
+- **Логи Worker**
+
+```bash
+npx wrangler tail
+```
+
+- **Redeploy**
+
+```bash
+npx wrangler deploy
+```
+
+- **Rollback (предыдущий стабильный commit)**
+
+```bash
+git checkout <PREVIOUS_STABLE_COMMIT>
+npx wrangler deploy
+```
+
+### Критерии инцидента
+
+Считать ситуацию инцидентом, если выполняется хотя бы один признак:
+
+1. Health check возвращает non-`200`.
+2. В `getWebhookInfo` присутствует `last_error_message` (не пустой).
+3. В `getWebhookInfo` растёт `pending_update_count` в повторных проверках.
+
+### Manual recheck checklist (после каждого deploy)
+
+1. Выполнить health check и убедиться в HTTP `200`.
+2. Проверить `getWebhookInfo`: верный `url`, пустой `last_error_message`.
+3. Повторно проверить `pending_update_count` через 1-2 минуты: счётчик не растёт.
+4. Открыть `npx wrangler tail` и проверить отсутствие новых ошибок на `/start` и одном callback (например, `co:main`).
+
 ## Локальная проверка
 
 ```bash


### PR DESCRIPTION
### Motivation
- Provide operators a concise, unambiguous runbook in the repository for Worker production checks, webhook validation, logging, redeploy/rollback steps, and a short post-deploy recheck to speed incident detection and response.

### Description
- Added a `Production operations` section to `README.md` that documents exact commands (`curl -i "$WORKER_URL/"`, Telegram `getWebhookInfo`, `npx wrangler tail`, `npx wrangler deploy`, and rollback via `git checkout <PREVIOUS_STABLE_COMMIT> && npx wrangler deploy`), explicit incident criteria (`non-200` health, non-empty `last_error_message`, rising `pending_update_count`), and a brief manual recheck checklist to run after each deploy.

### Testing
- Ran `node --check worker/worker.js` (OK) and `node --test tests/worker_smoke.test.mjs` (8/8 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea37042a0832ab9885445097e5672)